### PR TITLE
Moving the hero details into a separate, reusable HeroDetailComponent.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,11 +5,13 @@ import { FormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HeroesComponent } from './heroes/heroes.component';
+import { HeroDetailComponent } from './hero-detail/hero-detail.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    HeroesComponent
+    HeroesComponent,
+    HeroDetailComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/hero-detail/hero-detail.component.html
+++ b/src/app/hero-detail/hero-detail.component.html
@@ -1,0 +1,13 @@
+<p>hero-detail works!</p>
+<div *ngIf="hero">
+    <h2>{{hero.name | uppercase}} Details</h2>
+    <div><span>ID: </span>{{hero.id}}</div>
+    <div><span>Name: </span>{{hero.name}}</div>
+
+    <div>
+        <label>
+            Name:
+            <input [(ngModel)]="hero.name" placeholder="Type Name" />
+        </label>
+    </div>
+</div>

--- a/src/app/hero-detail/hero-detail.component.spec.ts
+++ b/src/app/hero-detail/hero-detail.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeroDetailComponent } from './hero-detail.component';
+
+describe('HeroDetailComponent', () => {
+  let component: HeroDetailComponent;
+  let fixture: ComponentFixture<HeroDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HeroDetailComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeroDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/hero-detail/hero-detail.component.ts
+++ b/src/app/hero-detail/hero-detail.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Hero } from '../hero';
+
+@Component({
+  selector: 'app-hero-detail',
+  templateUrl: './hero-detail.component.html',
+  styleUrls: ['./hero-detail.component.css']
+})
+export class HeroDetailComponent implements OnInit {
+  @Input() hero: Hero;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/heroes/heroes.component.html
+++ b/src/app/heroes/heroes.component.html
@@ -4,15 +4,5 @@
         <span class="badge">{{hero.id}}</span> {{hero.name}}
     </li>
 </ul>
-<div *ngIf="selectedHero">
-    <h2>{{selectedHero.name | uppercase}} Details</h2>
-    <div><span>ID: </span>{{selectedHero.id}}</div>
-    <div><span>Name: </span>{{selectedHero.name}}</div>
 
-    <div>
-        <label>
-            Name:
-            <input [(ngModel)]="selectedHero.name" placeholder="Type Name" />
-        </label>
-    </div>
-</div>
+<app-hero-detail [hero]="selectedHero"></app-hero-detail>


### PR DESCRIPTION
#### What does this PR do?
To move the hero details into a separate, reusable HeroDetailComponent.
#### Description of Task to be completed?
- I created a separate, reusable `HeroDetailComponent`.
- I used a property binding to give the parent `HeroesComponent` control over the child `HeroDetailComponent`.
- I used the `@Input` decorator to make the hero property available for binding by the external `HeroesComponent`.
#### How should this be manually tested?
By cloning the Repo, then run `npm i` and `ng serve --open`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
![Screenshot from 2020-05-23 21-41-05](https://user-images.githubusercontent.com/37714031/82739490-39b74000-9d40-11ea-8236-a0b1781c7185.png)
#### Questions: N/A